### PR TITLE
Allow using from node-0.8.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,17 +33,17 @@
     },
     "devDependencies": {
         "docco": "~0.3.0",
-        "mocha": "~0.14",
-        "jshint": "~0.5.9",
+        "mocha": "~1.2",
+        "jshint": "~0.7",
         "mbtiles": "~0.2.0",
         "tilejson": "~0.1.0",
-        "tilelive-mapnik": "~0.3.0"
+        "tilelive-mapnik": "~0.4.2"
     },
     "bin": {
         "tilelive": "./bin/tilelive"
     },
     "engines": {
-        "node": "~0.6.x"
+        "node": ">= 0.6.0"
     },
     "scripts": {
         "test": "make test"


### PR DESCRIPTION
Tweaks dependencies to allow using those with node-0.8.0 support
and allow any node version from 0.6+ to be used.

Passes "make test".

NOTE: requires a version of tilelive-mapnik which hasn't been
released at this time, see:
https://github.com/mapbox/tilelive-mapnik/pull/37
