### PR TITLE
More lenient validation of north and south bbox values.

### DIFF
--- a/lib/scanlinescheme.js
+++ b/lib/scanlinescheme.js
@@ -13,9 +13,9 @@ function ScanlineScheme(options) {
     if (!options.bbox) options.bbox = [ -180, -85.05112877980659, 180, 85.05112877980659 ];
     if (!Array.isArray(options.bbox) || options.bbox.length !== 4) throw new Error('bbox must have four lat/long coordinates');
     if (options.bbox[0] < -180) throw new Error('bbox has invalid west value');
-    if (options.bbox[1] < -85.05112877980659) throw new Error('bbox has invalid south value');
+    if (options.bbox[1] < -90) throw new Error('bbox has invalid south value');
     if (options.bbox[2] > 180) throw new Error('bbox has invalid east value');
-    if (options.bbox[3] > 85.05112877980659) throw new Error('bbox has invalid north value');
+    if (options.bbox[3] > 90) throw new Error('bbox has invalid north value');
     if (options.bbox[0] > options.bbox[2]) throw new Error('bbox is invalid');
     if (options.bbox[1] > options.bbox[3]) throw new Error('bbox is invalid');
     if (typeof options.minzoom !== 'number') throw new Error('minzoom must be a number');


### PR DESCRIPTION
This now matches the [validation in tilelive.js](https://github.com/mapbox/tilelive.js/blob/master/lib/tilelive.js#L190-198).
