### PR TITLE
Remove dependency on generic-pool

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
         "Konstantin Käfer <kkaefer>"
     ],
     "dependencies": {
-        "generic-pool": "~1.0.9",
         "optimist": "~0.3.1",
         "step": "~0.0.5",
         "sphericalmercator": "~1.0.1",


### PR DESCRIPTION
I started off trying to see if it was safe to update the `generic-pool` dependency to a newer version, but as far as I can see it is never actually used so I have removed it instead.
