### PR TITLE
Include the invalid protocol's value

### DIFF
--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -91,7 +91,7 @@ tilelive.load = function(uri, callback) {
     }
 
     if (!tilelive.protocols[uri.protocol]) {
-        return callback(new Error('Invalid tilesource protocol'));
+        return callback(new Error('Invalid tilesource protocol: ' + uri.protocol));
     }
 
     var handler = new tilelive.protocols[uri.protocol](uri, callback);

--- a/test/auto.test.js
+++ b/test/auto.test.js
@@ -10,7 +10,7 @@ describe('auto', function() {
         tilelive.protocols = {};
         tilelive.load('mbtiles://' + __dirname + '/fixtures/plain_1.mbtiles', function(err, source) {
             assert.ok(err);
-            assert.equal('Invalid tilesource protocol', err.message);
+            assert.equal('Invalid tilesource protocol: mbtiles:', err.message);
             done();
         });
     });

--- a/test/load.test.js
+++ b/test/load.test.js
@@ -111,7 +111,7 @@ describe('loading', function() {
     it('should refuse loading an invalid url', function(done) {
         tilelive.load('http://foo/bar', function(err) {
             assert.ok(err);
-            assert.equal(err.message, 'Invalid tilesource protocol');
+            assert.equal(err.message, 'Invalid tilesource protocol: http:');
             done();
         });
     });


### PR DESCRIPTION
This is handy when debugging tilelive sources.
