### PR TITLE
Pass on any errors when sink.startWriting

### DIFF
--- a/lib/copytask.js
+++ b/lib/copytask.js
@@ -139,7 +139,7 @@ CopyTask.prototype.start = function(callback) {
             init();
         });
         task.sink.startWriting(function(err) {
-            if (err) return callback();
+            if (err) return callback(err);
 
             // It is possible for a CopyTask to be paused before it
             // ever starts (SIGINT, exceptions, etc.) In these cases


### PR DESCRIPTION
I ran into this today, and the disappearing error took a while to figure out!
