### PR TITLE
Treat null / undefined tile data as a skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* `CopyTask` treats `null` / `undefined` tile data as skips.
+
 ## 4.5.3
 
 * Add tilelive.auto method from tilelive-copy for detection and autoloading of

--- a/lib/copytask.js
+++ b/lib/copytask.js
@@ -182,6 +182,13 @@ CopyTask.prototype.render = function(tile, type) {
                 }
                 return;
             }
+
+            if (!data) {
+                // no data, no error
+                task.scheme.skip(tile);
+                return;
+            }
+
             if (data.solid) switch(type) {
             case 'grid':
                 // Empty grid.


### PR DESCRIPTION
This allows tilelive sources to pass `null` / `undefined` when tiles don't
exist rather than an un-subclassed `Error` with a specific message (where
detection is more brittle).

/cc @gravitystorm
