### PR TITLE
Recent versions of sqlite seem to create bigger files

### DIFF
--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -44,7 +44,7 @@ describe('copying', function() {
                 if (err) throw err;
                 // There is some variance in the MBTiles size generated --
                 // possibly related to the timing in which data is inserted.
-                assert.ok(info.filesize > 39900 && info.filesize < 41000);
+                assert.ok(info.filesize > 39900 && info.filesize < 46000);
                 delete info.filesize;
                 assert.deepEqual({
                     scheme: 'tms',


### PR DESCRIPTION
With the version of sqlite (3.8.4.3) currently in Fedora I seem to get a size in the 43000 to 45000 byte range.
