### PR TITLE
Support `auto` for modules that export factories

### DIFF
--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -101,8 +101,17 @@ tilelive.auto = function(uri) {
     uri.protocol = uri.protocol || keyword + ':';
 
     if (!tilelive.protocols[uri.protocol]) {
-        try { require(keyword).registerProtocols(tilelive); } catch(err) {};
-        try { require('tilelive-' + keyword).registerProtocols(tilelive); } catch(err) {};
+        [keyword, 'tilelive-' + keyword].forEach(function(name) {
+            try {
+                var mod = require(name);
+
+                if (typeof(mod.registerProtocols) === 'function') {
+                    mod.registerProtocols(tilelive);
+                } else {
+                    mod(tilelive);
+                }
+            } catch(err) {};
+        });
     }
 
     return uri;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "devDependencies": {
         "tape": "2.13.3",
         "mbtiles": "~0.4.3",
-        "tilejson": "~0.8.0"
+        "tilejson": "~0.8.0",
+        "tilelive-http": "^0.3.0"
     },
     "bin": {
         "tilelive-copy": "./bin/tilelive-copy"

--- a/test/auto.test.js
+++ b/test/auto.test.js
@@ -51,6 +51,16 @@ test('auto protocol tilejson://', function(t) {
         t.end();
     });
 });
+test('auto protocol http://', function(t) {
+    tilelive.protocols = {};
+    var uri = tilelive.auto('http://tile.stamen.com/toner/{z}/{x}/{y}.png');
+    t.equal('http:', uri.protocol);
+    tilelive.load(uri, function(err, source) {
+        t.ifError(err);
+        t.ok(source);
+        t.end();
+    });
+});
 test('cleanup', function(t) {
     tilelive.protocols = orig;
     t.end();


### PR DESCRIPTION
Most of my tilelive modules export factories rather than providers directly in order to reduce the proliferation of explicit dependencies on (and instances of, though that's been mitigated with the global registry) tilelive.  (This also also allows tilelive facades, such as [tilelive-cache](https://github.com/mojodna/tilelive-cache), to be provided instead.)

This detects the form of a provider and registers it appropriately.
