### PR TITLE
Treat missing tile data as a skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Streams treat missing tile data as skips.
+
 ## 5.0.0
 
 * Refactor CopyTask into read/write streams

--- a/lib/stream-list.js
+++ b/lib/stream-list.js
@@ -59,7 +59,7 @@ List.prototype._read = function(size) {
         stream.source.getTile(zxy.z, zxy.x, zxy.y, function(err, buffer) {
             if (err && !(/does not exist$/).test(err.message)) {
                 stream.emit('error', err);
-            } else if (err || isEmpty(buffer)) {
+            } else if (err || !buffer || isEmpty(buffer)) {
                 stream.stats.skipped++;
                 stream.stats.done++;
                 get(push);

--- a/lib/stream-pyramid.js
+++ b/lib/stream-pyramid.js
@@ -106,7 +106,7 @@ Pyramid.prototype._read = function(size) {
             stream.pending--;
             if (err && !(/does not exist$/).test(err.message)) {
                 stream.emit('error', err);
-            } else if (err || isEmpty(buffer)) {
+            } else if (err || !buffer || isEmpty(buffer)) {
                 tile = new Tile(z, x, y);
                 var sum = sumChildren(tile, stream.bboxes);
                 stream.stats.skipped += 1 + sum;

--- a/lib/stream-scanline.js
+++ b/lib/stream-scanline.js
@@ -83,7 +83,7 @@ Scanline.prototype._read = function(size) {
         stream.source.getTile(z, x, y, function(err, buffer) {
             if (err && !(/does not exist$/).test(err.message)) {
                 stream.emit('error', err);
-            } else if (err || isEmpty(buffer)) {
+            } else if (err || !buffer || isEmpty(buffer)) {
                 stream.stats.skipped++;
                 stream.stats.done++;
                 get(push);


### PR DESCRIPTION
This allows tilelive sources to pass null / undefined when tiles don't exist rather than an un-subclassed Error with a specific message (where detection is more brittle).

Replaces #66
