### PR TITLE
Check stream types

### DIFF
--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -237,7 +237,7 @@ tilelive.createReadStream = function(source, options) {
     options = options || {};
     options.type = options.type || 'scanline';
     var result = new tilelive.streamTypes[options.type](source, options);
-    if (!result instanceof stream.Readable)
+    if (!(result instanceof stream.Readable))
         throw new Error(options.type + ' is not a valid readable stream type');
     return result;
 };
@@ -246,7 +246,7 @@ tilelive.createWriteStream = function(source, options) {
     options = options || {};
     options.type = options.type || 'put';
     var result = new tilelive.streamTypes[options.type](source, options);
-    if (!result instanceof stream.Writable)
+    if (!(result instanceof stream.Writable))
         throw new Error(options.type + ' is not a valid writable stream type');
     return result;
 };

--- a/test/stream-api.test.js
+++ b/test/stream-api.test.js
@@ -1,0 +1,39 @@
+var test = require('tape');
+var MBTiles = require('mbtiles');
+var tilelive = require('..');
+var fs = require('fs');
+var path = require('path');
+
+var src;
+
+test('stream-api: src', function(t) {
+    new MBTiles(__dirname + '/fixtures/plain_1.mbtiles', function(err, s) {
+        t.ifError(err);
+        src = s;
+        t.end();
+    });
+});
+
+test('stream-api: valid readable', function(t) {
+    var fn = tilelive.createReadStream.bind(tilelive, src, { type: 'list' });
+    t.doesNotThrow(fn);
+    t.end();
+});
+
+test('stream-api: invalid reabable', function(t) {
+    var fn = tilelive.createReadStream.bind(tilelive, src, { type: 'put' });
+    t.throws(fn);
+    t.end();
+});
+
+test('stream-api: valid writable', function(t) {
+    var fn = tilelive.createWriteStream.bind(tilelive, src, { type: 'put' });
+    t.doesNotThrow(fn);
+    t.end();
+});
+
+test('stream-api: invalid writable', function(t) {
+    var fn = tilelive.createWriteStream.bind(tilelive, src, { type: 'list' });
+    t.throws(fn);
+    t.end();
+});


### PR DESCRIPTION
... so that you cannot

``` javascript
var src = getMyTileSource();
var wut = tilelive.createReadStream(src, { type: 'put' });
```

Worth keeping in mind that duplex and transform streams will register as `instanceof stream.Readable` but will not register as `instanceof stream.Writable`. [From the docs:](http://nodejs.org/api/stream.html#stream_class_stream_duplex_1)

> Since JavaScript doesn't have multiple prototypal inheritance, this class prototypally inherits from Readable, and then parasitically from Writable.
