### PR TITLE
Use console.log instead of util.print

### DIFF
--- a/bin/tilelive-copy
+++ b/bin/tilelive-copy
@@ -96,7 +96,7 @@ function copy() {
 }
 
 function report(stats, p) {
-    util.print(util.format('\r\033[K[%s] %s%% %s/%s @ %s/s | ✓ %s □ %s | %s left',
+    console.log(util.format('\r\033[K[%s] %s%% %s/%s @ %s/s | ✓ %s □ %s | %s left',
         pad(formatDuration(process.uptime()), 4, true),
         pad((p.percentage).toFixed(4), 8, true),
         pad(formatNumber(p.transferred),6,true),


### PR DESCRIPTION
Testing with node v.12.x gives:

```
leftutil.print: Use console.log instead
```

which breaks the tilelive-copy reporting (causes it to repeat itself on many lines). Should be fine to merge assuming travis passes.