### PR TITLE
Handle null uri.pathname bug

### DIFF
--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -76,7 +76,9 @@ tilelive.load = function(uri, callback) {
 
     if (typeof uri === 'string') {
         uri = url.parse(uri, true);
-        uri.pathname = qs.unescape(uri.pathname);
+        if (uri.pathname) {
+            uri.pathname = qs.unescape(uri.pathname);
+        }
     }
 
     // Handle uris in the format /path/to/dir?id=bar

--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -76,6 +76,7 @@ tilelive.load = function(uri, callback) {
 
     if (typeof uri === 'string') {
         uri = url.parse(uri, true);
+        // Special handling for Node <= 0.10
         if (uri.pathname) {
             uri.pathname = qs.unescape(uri.pathname);
         }

--- a/test/load.test.js
+++ b/test/load.test.js
@@ -141,6 +141,21 @@ var data = [
     }
 ];
 
+test('loading: url without pathname', function(t) {
+    // Create a dummy protocol handler
+    tilelive.protocols['nopathname:'] = function NoPathNameSource(uri, callback) {
+        this.search = uri.search;
+        callback(undefined, this);
+    };
+    var searchStr = '?test=1';
+    tilelive.load('nopathname://' + searchStr, function(err, source) {
+        if (err) throw err;
+        t.equal(source.search, searchStr);
+        delete tilelive.protocols['nopathname:'];
+        t.end();
+    });
+});
+
 test('loading: no callback no fun', function(t) {
     t.throws(function() {
         tilelive.load('http://foo/bar');


### PR DESCRIPTION
Sometimes modules do not require a full path,
and can use shorter version, e.g.   overzoom://?source=blah
which results in the null pathname, which fails in the unescape.