### PR TITLE
Autoloading: handle protocols with +

### DIFF
--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -101,7 +101,7 @@ tilelive.auto = function(uri) {
 
     // Attempt to load any modules that may match keyword pattern.
     var keyword = uri.protocol
-        ? uri.protocol.replace(':', '')
+        ? uri.protocol.replace(':', '').split('+')[0]
         : path.extname(uri.pathname).replace('.', '');
     uri.protocol = uri.protocol || keyword + ':';
 

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "istanbul": "~0.3.0",
     "mbtiles": "~0.7.7",
     "tape": "2.13.3",
-    "tilejson": "~0.8.0",
-    "tilelive-http": "^0.3.0"
+    "tilejson": "~1.0.0"
   },
   "bin": {
     "tilelive-copy": "./bin/tilelive-copy"

--- a/test/auto.test.js
+++ b/test/auto.test.js
@@ -51,6 +51,16 @@ test('auto protocol tilejson://', function(t) {
         t.end();
     });
 });
+test('auto protocol tilejson+http://', function(t) {
+    tilelive.protocols = {};
+    var uri = tilelive.auto('tilejson+http://tile.stamen.com/toner/index.json');
+    t.equal('tilejson+http:', uri.protocol);
+    tilelive.load(uri, function(err, source) {
+        t.ifError(err);
+        t.ok(source);
+        t.end();
+    });
+});
 test('auto protocol http://', function(t) {
     tilelive.protocols = {};
     var uri = tilelive.auto('http://tile.stamen.com/toner/{z}/{x}/{y}.png');

--- a/test/auto.test.js
+++ b/test/auto.test.js
@@ -61,16 +61,6 @@ test('auto protocol tilejson+http://', function(t) {
         t.end();
     });
 });
-test('auto protocol http://', function(t) {
-    tilelive.protocols = {};
-    var uri = tilelive.auto('http://tile.stamen.com/toner/{z}/{x}/{y}.png');
-    t.equal('http:', uri.protocol);
-    tilelive.load(uri, function(err, source) {
-        t.ifError(err);
-        t.ok(source);
-        t.end();
-    });
-});
 test('cleanup', function(t) {
     tilelive.protocols = orig;
     t.end();

--- a/test/load.test.js
+++ b/test/load.test.js
@@ -141,6 +141,13 @@ var data = [
     }
 ];
 
+test('loading: no callback no fun', function(t) {
+    t.throws(function() {
+        tilelive.load('http://foo/bar');
+    });
+    t.end();
+});
+
 test('loading: should refuse loading an invalid url', function(t) {
     tilelive.load('http://foo/bar', function(err) {
         t.ok(err);


### PR DESCRIPTION
Fixes autoloading when a protocol includes the `+`. Expects that the handler is the early part of the protocol (e.g. `tilejson+http` => load via `tilejson`).

cc @mick 