### PR TITLE
parse the querystring everywhere we parse the url

### DIFF
--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -96,7 +96,7 @@ tilelive.load = function(uri, callback) {
 };
 
 tilelive.auto = function(uri) {
-    uri = url.parse(uri);
+    uri = url.parse(uri, true);
     uri.pathname = qs.unescape(uri.pathname);
 
     // Attempt to load any modules that may match keyword pattern.

--- a/test/auto.test.js
+++ b/test/auto.test.js
@@ -61,8 +61,14 @@ test('auto protocol http://', function(t) {
         t.end();
     });
 });
+test('auto should parse qs ', function(t) {
+    tilelive.protocols = {};
+    var uri = tilelive.auto('http://tile.stamen.com/toner/{z}/{x}/{y}.png?foo=bar');
+    t.equal('http:', uri.protocol);
+    t.equal('bar', uri.query.foo);
+    t.end();
+});
 test('cleanup', function(t) {
     tilelive.protocols = orig;
     t.end();
 });
-


### PR DESCRIPTION
missing the 2nd argument `true` to `url.parse` in `tilelive.auto()` 

[`tilvelive.copy()` uses the parsed return from `tilelive.auto`](https://github.com/mapbox/tilelive/blob/master/lib/tilelive.js#L332-L333), downstream other tilvelive modules only check to see if uri is parsed and expect that to mean the querystring is parsed too.


cc @yhahn 