### PR TITLE
Add logging to stderr for slow tiles (get/put) during a tilelive-copy

### DIFF
--- a/bin/tilelive-copy
+++ b/bin/tilelive-copy
@@ -102,7 +102,7 @@ function copy() {
 }
 
 function report(stats, p) {
-    util.print(util.format('\r\033[K[%s] %s%% %s/%s @ %s/s | ✓ %s □ %s | %s left',
+    console.log(util.format('\r\033[K[%s] %s%% %s/%s @ %s/s | ✓ %s □ %s | %s left',
         pad(formatDuration(process.uptime()), 4, true),
         pad((p.percentage).toFixed(4), 8, true),
         pad(formatNumber(p.transferred),6,true),

--- a/bin/tilelive-copy
+++ b/bin/tilelive-copy
@@ -30,6 +30,7 @@ if (!argv._[0]) {
     console.log('  --concurrency=[number]            Copy concurrency.');
     console.log('  --withoutprogress                 Shows progress by default.');
     console.log('  --timeout=[number]                Timeout after n ms of inactivity.');
+    console.log('  --slow=[number]                   Warn on slow tiles.');
     console.log('  --bounds=[w,s,e,n]');
     console.log('  --minzoom=[number]');
     console.log('  --maxzoom=[number]');
@@ -50,6 +51,7 @@ argv.parts = isNumeric(argv.parts) ? argv.parts : undefined;
 argv.part = isNumeric(argv.part) ? argv.part : undefined;
 argv.retry = isNumeric(argv.retry) ? parseInt(argv.retry,10) : undefined;
 argv.timeout = isNumeric(argv.timeout) ? parseInt(argv.timeout,10) : undefined;
+argv.slow = isNumeric(argv.slow) ? parseInt(argv.slow,10) : undefined;
 
 if (argv.scheme !== 'pyramid' && argv.scheme !== 'scanline' && argv.scheme !== 'list') {
     console.warn('scheme must be one of pyramid, scanline, list');
@@ -76,6 +78,7 @@ function copy() {
         maxzoom:argv.maxzoom,
         bounds:argv.bounds,
         retry:argv.retry,
+        slow:argv.slow,
         timeout:argv.timeout,
         close:true
     };

--- a/bin/tilelive-copy
+++ b/bin/tilelive-copy
@@ -95,6 +95,10 @@ function copy() {
     }
     if (!dsturi) options.outStream = process.stdout;
 
+    if (options.slow) options.onslow = function(method, z, x, y, time) {
+        console.warn('[slow tile] %s %d/%d/%d %dms', method, z, x, y, time);
+    };
+
     tilelive.copy(srcuri, dsturi, options, function(err) {
         if (err) throw err;
         console.log('');

--- a/lib/stream-list.js
+++ b/lib/stream-list.js
@@ -73,7 +73,7 @@ List.prototype._readTiles = function(callback) {
         if (stream.job && zxy.x % stream.job.total !== stream.job.num)
             return skip();
 
-        getTileRetry(stream.source, zxy.z, zxy.x, zxy.y, stream.retry, function(err, buffer) {
+        getTileRetry(stream.source, zxy.z, zxy.x, zxy.y, stream.retry, stream, function(err, buffer) {
             if (err && !(/does not exist$/).test(err.message)) {
                 done(err);
             } else if (err || isEmpty(buffer)) {

--- a/lib/stream-put.js
+++ b/lib/stream-put.js
@@ -58,7 +58,7 @@ Put.prototype._write = function(obj, encoding, callback) {
     multiwrite(stream, callback, function write(done) {
         if (obj instanceof Tile) {
             stream.stats.ops++;
-            return putTileRetry(stream.source, obj.z, obj.x, obj.y, obj.buffer, stream.retry, function(err) {
+            return putTileRetry(stream.source, obj.z, obj.x, obj.y, obj.buffer, stream.retry, stream, function(err) {
                 if (err) return done(err);
                 stream.stats.done++;
                 done();

--- a/lib/stream-pyramid.js
+++ b/lib/stream-pyramid.js
@@ -107,7 +107,7 @@ Pyramid.prototype._read = function() {
             y = queued.y;
             stream.pending++;
             stream.stats.ops++;
-            getTileRetry(stream.source, z, x, y, stream.retry, done);
+            getTileRetry(stream.source, z, x, y, stream.retry, stream, done);
             // Do not repeat buffers in a pyramid fashion for now as
             // there are possible false positives in upstream solid
             // detection.
@@ -125,7 +125,7 @@ Pyramid.prototype._read = function() {
             nextShallow(stream);
             stream.pending++;
             stream.stats.ops++;
-            getTileRetry(stream.source, z, x, y, stream.retry, done);
+            getTileRetry(stream.source, z, x, y, stream.retry, stream, done);
             return true;
         } else {
             return push(null) && false;

--- a/lib/stream-scanline.js
+++ b/lib/stream-scanline.js
@@ -96,7 +96,7 @@ Scanline.prototype._read = function(/* size */) {
         if (stream.job && x % stream.job.total !== stream.job.num)
             return skip();
 
-        getTileRetry(stream.source, z, x, y, stream.retry, function(err, buffer) {
+        getTileRetry(stream.source, z, x, y, stream.retry, stream, function(err, buffer) {
             if (err && !(/does not exist$/).test(err.message)) {
                 stream.emit('error', err);
             } else if (err || isEmpty(buffer)) {

--- a/lib/stream-util.js
+++ b/lib/stream-util.js
@@ -19,6 +19,7 @@ module.exports.serialHeader = 'JSONBREAKFASTTIME';
 module.exports.getTileRetry = getTileRetry;
 module.exports.putTileRetry = putTileRetry;
 module.exports.retryBackoff = 1000;
+module.exports.slowTime = 60e3;
 
 function DeserializationError(msg) {
     this.message = msg;
@@ -215,6 +216,7 @@ function setConcurrency(c) {
     return concurrency;
 }
 
+
 /**
  * Limit a bounding box to the [-180, -90, 180, 90] limits
  * of WGS84. We permit greater bounds for input data, since sometimes
@@ -235,14 +237,18 @@ function limitBounds(bounds) {
     });
 }
 
-function getTileRetry(source, z, x, y, tries, callback) {
-    tries = typeof tries === 'number' ? { max:tries, num:0 } : tries;
+function getTileRetry(source, z, x, y, tries, stream, callback) {
+    tries = typeof tries === 'number' ? {
+        max: tries,
+        num: 0,
+        startTime: +new Date()
+    } : tries;
     source.getTile(z, x, y, function(err /*, tile, headers */) {
         if (err && err.message === 'Tile does not exist') {
             callback.apply(this, arguments);
         } else if (err && tries.num++ < tries.max) {
             setTimeout(function() {
-                getTileRetry(source, z, x, y, tries, callback);
+                getTileRetry(source, z, x, y, tries, stream, callback);
             }, Math.pow(2, tries.num) * module.exports.retryBackoff);
         } else {
             callback.apply(this, arguments);
@@ -250,12 +256,16 @@ function getTileRetry(source, z, x, y, tries, callback) {
     });
 }
 
-function putTileRetry(source, z, x, y, data, tries, callback) {
-    tries = typeof tries === 'number' ? { max:tries, num:0 } : tries;
+function putTileRetry(source, z, x, y, data, tries, stream, callback) {
+    tries = typeof tries === 'number' ? {
+        max: tries,
+        num: 0,
+        startTime: +new Date()
+    } : tries;
     source.putTile(z, x, y, data, function(err) {
         if (err && tries.num++ < tries.max) {
             setTimeout(function() {
-                putTileRetry(source, z, x, y, data, tries, callback);
+                putTileRetry(source, z, x, y, data, tries, stream, callback);
             }, Math.pow(2, tries.num) * module.exports.retryBackoff);
         } else {
             callback.apply(this, arguments);

--- a/lib/stream-util.js
+++ b/lib/stream-util.js
@@ -19,7 +19,7 @@ module.exports.serialHeader = 'JSONBREAKFASTTIME';
 module.exports.getTileRetry = getTileRetry;
 module.exports.putTileRetry = putTileRetry;
 module.exports.retryBackoff = 1000;
-module.exports.slowTime = 60e3;
+module.exports.slowTime = 10e3;
 
 function DeserializationError(msg) {
     this.message = msg;

--- a/lib/stream-util.js
+++ b/lib/stream-util.js
@@ -241,9 +241,17 @@ function getTileRetry(source, z, x, y, tries, stream, callback) {
     tries = typeof tries === 'number' ? {
         max: tries,
         num: 0,
-        startTime: +new Date()
+        startTime: new Date(),
+        logged: false
     } : tries;
     source.getTile(z, x, y, function(err /*, tile, headers */) {
+        // Get time taken and emit slow event if over the slowTime threshold.
+        var time = new Date() - tries.startTime;
+        if (!tries.logged && time > module.exports.slowTime) {
+            tries.logged = true;
+            stream.emit('slow', 'get', z, x, y, time);
+        }
+
         if (err && err.message === 'Tile does not exist') {
             callback.apply(this, arguments);
         } else if (err && tries.num++ < tries.max) {
@@ -260,9 +268,17 @@ function putTileRetry(source, z, x, y, data, tries, stream, callback) {
     tries = typeof tries === 'number' ? {
         max: tries,
         num: 0,
-        startTime: +new Date()
+        startTime: new Date(),
+        logged: false
     } : tries;
     source.putTile(z, x, y, data, function(err) {
+        // Get time taken and emit slow event if over the slowTime threshold.
+        var time = new Date() - tries.startTime;
+        if (!tries.logged && time > module.exports.slowTime) {
+            tries.logged = true;
+            stream.emit('slow', 'put', z, x, y, time);
+        }
+
         if (err && tries.num++ < tries.max) {
             setTimeout(function() {
                 putTileRetry(source, z, x, y, data, tries, stream, callback);

--- a/lib/stream-util.js
+++ b/lib/stream-util.js
@@ -247,7 +247,7 @@ function getTileRetry(source, z, x, y, tries, stream, callback) {
     source.getTile(z, x, y, function(err /*, tile, headers */) {
         // Get time taken and emit slow event if over the slowTime threshold.
         var time = new Date() - tries.startTime;
-        if (!tries.logged && time > module.exports.slowTime) {
+        if (!tries.logged && module.exports.slowTime && time > module.exports.slowTime) {
             tries.logged = true;
             stream.emit('slow', 'get', z, x, y, time);
         }
@@ -274,7 +274,7 @@ function putTileRetry(source, z, x, y, data, tries, stream, callback) {
     source.putTile(z, x, y, data, function(err) {
         // Get time taken and emit slow event if over the slowTime threshold.
         var time = new Date() - tries.startTime;
-        if (!tries.logged && time > module.exports.slowTime) {
+        if (!tries.logged && module.exports.slowTime && time > module.exports.slowTime) {
             tries.logged = true;
             stream.emit('slow', 'put', z, x, y, time);
         }

--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -396,13 +396,9 @@ tilelive.copy = function(src, dst, options, callback) {
         put.on('error', done);
         get.on('length', prog.setLength);
 
-        if (options.slow) {
-            get.on('slow', function(method, z, x, y, time) {
-                console.warn('[slow tile] %s %d/%d/%d %dms', method, z, x, y, time);
-            });
-            put.on('slow', function(method, z, x, y, time) {
-                console.warn('[slow tile] %s %d/%d/%d %dms', method, z, x, y, time);
-            });
+        if (options.onslow) {
+            get.on('slow', options.onslow);
+            put.on('slow', options.onslow);
         }
 
         if (options.progress)

--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -310,10 +310,14 @@ tilelive.copy = function(src, dst, options, callback) {
     if (options.type === 'list' && !options.listStream) {
         return callback(new Error('You must provide a listStream'));
     }
+
     if (!dst && !options.outStream) {
         return callback(new Error('You must provide either a dsturi or an output stream'));
     }
     if (options.concurrency) tilelive.stream.setConcurrency(options.concurrency);
+
+    // set up slow tile logging threshold
+    if (options.slow) tilelive.stream.slowTime = options.slow;
 
     // if (options.transform && (!options.transform._write || !options.transform._read)) {
     if (options.transform && !(options.transform instanceof stream.Transform)) {
@@ -391,6 +395,15 @@ tilelive.copy = function(src, dst, options, callback) {
         get.on('error', done);
         put.on('error', done);
         get.on('length', prog.setLength);
+
+        if (options.slow) {
+            get.on('slow', function(method, z, x, y, time) {
+                console.warn('[slow tile] %s %d/%d/%d %dms', method, z, x, y, time);
+            });
+            put.on('slow', function(method, z, x, y, time) {
+                console.warn('[slow tile] %s %d/%d/%d %dms', method, z, x, y, time);
+            });
+        }
 
         if (options.progress)
             prog.on('progress', function(p) { options.progress(get.stats, p); });

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -396,7 +396,7 @@ test('tilelive.copy not a transform', function(t) {
 
 // Used for progress report
 function report(stats, p) {
-    util.print(util.format('\r\033[K[%s] %s%% %s/%s @ %s/s | ✓ %s □ %s | %s left',
+    console.log(util.format('\r\033[K[%s] %s%% %s/%s @ %s/s | ✓ %s □ %s | %s left',
         pad(formatDuration(process.uptime()), 4, true),
         pad((p.percentage).toFixed(4), 8, true),
         pad(formatNumber(p.transferred),6,true),

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -12,6 +12,7 @@ var MBTiles = require('mbtiles');
 MBTiles.registerProtocols(tilelive);
 var crypto = require('crypto');
 var Timedsource = require('./timedsource');
+var out = [];
 
 var s3url = 's3://tilestream-tilesets-development/carol-staging/mapbox-tile-copy/{z}/{x}/{y}.png';
 
@@ -45,6 +46,7 @@ test('copy min/max', function(t) {
     var filepath = path.join(tmp, crypto.randomBytes(12).toString('hex') + '.copy_minmax.mbtiles');
     exec(__dirname + '/../bin/tilelive-copy --minzoom=1 --maxzoom=2 ' + __dirname + '/fixtures/plain_1.mbtiles ' + filepath, function(err, stdout, stderr) {
         t.ifError(err, 'no errors');
+        t.equal(stderr, '', 'no stderr');
         t.ok(stdout.indexOf('100.0000%') !== -1, 'pct complete');
         t.ok(stdout.indexOf('21/') !== -1, '21');
         t.end();
@@ -55,6 +57,7 @@ test('copy bounds', function(t) {
     var filepath = path.join(tmp, crypto.randomBytes(12).toString('hex') + '.copy_bounds.mbtiles');
     exec(__dirname + '/../bin/tilelive-copy --bounds=-180,-85,0,0 ' + __dirname + '/fixtures/plain_1.mbtiles ' + filepath, function(err, stdout, stderr) {
         t.ifError(err, 'no errors');
+        t.equal(stderr, '', 'no stderr');
         t.ok(stdout.indexOf('100.0000%') !== -1, 'pct complete');
         t.ok(stdout.indexOf('59') !== -1, '59');
         t.end();
@@ -65,6 +68,7 @@ test('copy list', function(t) {
     var filepath = path.join(tmp, crypto.randomBytes(12).toString('hex') + '.copy_list.mbtiles');
     exec(__dirname + '/../bin/tilelive-copy --scheme=list --list=' + __dirname + '/fixtures/filescheme.flat ' + __dirname + '/fixtures/plain_1.mbtiles ' + filepath, function(err, stdout, stderr) {
         t.ifError(err, 'no errors');
+        t.equal(stderr, '', 'no stderr');
         t.ok(stdout.indexOf('100.0000%') !== -1, 'pct complete');
         t.ok(stdout.indexOf('77') !== -1, '77');
         t.end();
@@ -74,6 +78,7 @@ test('copy list', function(t) {
 test('copy streams', function(t) {
     exec(__dirname + '/../bin/tilelive-copy ' + __dirname + '/fixtures/plain_1.mbtiles', {maxBuffer:5e6}, function(err, stdout, stderr) {
         t.ifError(err, 'no errors');
+        t.equal(stderr, '', 'no stderr');
         t.ok(stdout.indexOf('JSONBREAKFASTTIME\n') === 0);
         t.equal(stdout.length, 647001);
         t.end();
@@ -83,6 +88,7 @@ test('copy streams', function(t) {
 test('copy part zero', function(t) {
     exec(__dirname + '/../bin/tilelive-copy ' + __dirname + '/fixtures/plain_1.mbtiles --part 0 --parts 10', function(err, stdout, stderr) {
         t.ifError(err, 'no errors');
+        t.equal(stderr, '', 'no stderr');
         t.ok(stdout.split('\n').length < 287, 'does not render all tiles');
         t.end();
     });
@@ -92,6 +98,15 @@ test('copy timeout', function(t) {
     exec(__dirname + '/../bin/tilelive-copy ' + __dirname + '/fixtures/plain_1.mbtiles --timeout=1', function(err, stdout, stderr) {
         t.ok(err);
         t.ok(/Copy operation timed out/.test(stderr));
+        t.end();
+    });
+});
+
+test('copy slow', function(t) {
+    var filepath = path.join(tmp, crypto.randomBytes(12).toString('hex') + '.copy_slow.mbtiles');
+    exec(__dirname + '/../bin/tilelive-copy --slow=20 ' + __dirname + '/fixtures/plain_1.mbtiles ' + filepath, function(err, stdout, stderr) {
+        t.ifError(err, 'no errors');
+        t.ok((/\[slow tile\] get \d+\/\d+\/\d+ \d+ms/).test(stderr), 'logs slow tiles to stderr');
         t.end();
     });
 });

--- a/test/stream-util.test.js
+++ b/test/stream-util.test.js
@@ -6,6 +6,7 @@ var path = require('path');
 var util = require('../lib/stream-util');
 var assert = require('assert');
 var Timedsource = require('./timedsource');
+var EventEmitter = require('events').EventEmitter;
 
 test('retryBackoff (setup)', function(assert) {
     util.retryBackoff = 10;
@@ -14,7 +15,8 @@ test('retryBackoff (setup)', function(assert) {
 
 test('putTileRetry fail=2, tries=2', function(assert) {
     var source = new Timedsource({fail:2});
-    util.putTileRetry(source, 0, 0, 0, new Buffer(0), 2, function(err) {
+    var emitter = new EventEmitter();
+    util.putTileRetry(source, 0, 0, 0, new Buffer(0), 2, emitter, function(err) {
         assert.equal(source.fails['0/0/0'], 2, 'failed x2');
         assert.ifError(err, 'no error');
         assert.end();
@@ -23,7 +25,8 @@ test('putTileRetry fail=2, tries=2', function(assert) {
 
 test('putTileRetry fail=2, retry=1', function(assert) {
     var source = new Timedsource({fail:2});
-    util.putTileRetry(source, 0, 0, 0, new Buffer(0), 1, function(err) {
+    var emitter = new EventEmitter();
+    util.putTileRetry(source, 0, 0, 0, new Buffer(0), 1, emitter, function(err) {
         assert.equal(source.fails['0/0/0'], 2, 'failed x2');
         assert.equal(err.toString(), 'Error: Fatal', 'passes error');
         assert.end();
@@ -32,7 +35,8 @@ test('putTileRetry fail=2, retry=1', function(assert) {
 
 test('putTileRetry fail=1, retry=0', function(assert) {
     var source = new Timedsource({fail:1});
-    util.putTileRetry(source, 0, 0, 0, new Buffer(0), 0, function(err) {
+    var emitter = new EventEmitter();
+    util.putTileRetry(source, 0, 0, 0, new Buffer(0), 0, emitter, function(err) {
         assert.equal(source.fails['0/0/0'], 1, 'failed x1');
         assert.equal(err.toString(), 'Error: Fatal', 'passes error');
         assert.end();
@@ -41,7 +45,8 @@ test('putTileRetry fail=1, retry=0', function(assert) {
 
 test('putTileRetry fail=0, retry=0', function(assert) {
     var source = new Timedsource({fail:0});
-    util.putTileRetry(source, 0, 0, 0, new Buffer(0), 0, function(err) {
+    var emitter = new EventEmitter();
+    util.putTileRetry(source, 0, 0, 0, new Buffer(0), 0, emitter, function(err) {
         assert.equal(source.fails['0/0/0'], undefined, 'failed x0');
         assert.ifError(err, 'no error');
         assert.end();
@@ -50,7 +55,8 @@ test('putTileRetry fail=0, retry=0', function(assert) {
 
 test('getTileRetry fail=2, retry=2', function(assert) {
     var source = new Timedsource({fail:2});
-    util.getTileRetry(source, 0, 0, 0, 2, function(err, data, headers) {
+    var emitter = new EventEmitter();
+    util.getTileRetry(source, 0, 0, 0, 2, emitter, function(err, data, headers) {
         assert.equal(source.fails['0/0/0'], 2, 'failed x2');
         assert.ifError(err, 'no error');
         assert.equal(data instanceof Buffer, true, 'passes buffer');
@@ -61,7 +67,8 @@ test('getTileRetry fail=2, retry=2', function(assert) {
 
 test('getTileRetry fail=2, retry=1', function(assert) {
     var source = new Timedsource({fail:2});
-    util.getTileRetry(source, 0, 0, 0, 1, function(err, data, headers) {
+    var emitter = new EventEmitter();
+    util.getTileRetry(source, 0, 0, 0, 1, emitter, function(err, data, headers) {
         assert.equal(source.fails['0/0/0'], 2, 'failed x2');
         assert.equal(err.toString(), 'Error: Fatal', 'passes error');
         assert.end();
@@ -71,7 +78,8 @@ test('getTileRetry fail=2, retry=1', function(assert) {
 
 test('getTileRetry fail=1, retry=0', function(assert) {
     var source = new Timedsource({fail:1});
-    util.getTileRetry(source, 0, 0, 0, 0, function(err, data, headers) {
+    var emitter = new EventEmitter();
+    util.getTileRetry(source, 0, 0, 0, 0, emitter, function(err, data, headers) {
         assert.equal(source.fails['0/0/0'], 1, 'failed x1');
         assert.equal(err.toString(), 'Error: Fatal', 'passes error');
         assert.end();
@@ -80,7 +88,8 @@ test('getTileRetry fail=1, retry=0', function(assert) {
 
 test('getTileRetry fail=0, retry=0', function(assert) {
     var source = new Timedsource({fail:0});
-    util.getTileRetry(source, 0, 0, 0, 0, function(err, data, headers) {
+    var emitter = new EventEmitter();
+    util.getTileRetry(source, 0, 0, 0, 0, emitter, function(err, data, headers) {
         assert.equal(source.fails['0/0/0'], undefined, 'failed x0');
         assert.ifError(err, 'no error');
         assert.equal(data instanceof Buffer, true, 'passes buffer');
@@ -91,7 +100,8 @@ test('getTileRetry fail=0, retry=0', function(assert) {
 
 test('getTileRetry Does Not Exist, retry=3', function(assert) {
     var source = new Timedsource({fail:0});
-    util.getTileRetry(source, 1, 1, 0, 3, function(err, data, headers) {
+    var emitter = new EventEmitter();
+    util.getTileRetry(source, 1, 1, 0, 3, emitter, function(err, data, headers) {
         assert.equal(source.gets, 1, '1 attempt');
         assert.equal(err.toString(), 'Error: Tile does not exist');
         assert.end();

--- a/test/stream-util.test.js
+++ b/test/stream-util.test.js
@@ -76,6 +76,17 @@ test('putTileRetry (slow)', function(assert) {
     });
 });
 
+test('putTileRetry (slow=0)', function(assert) {
+    util.slowTime = 0;
+    var source = new Timedsource({fail:0, time:100});
+    var emitter = new EventEmitter();
+    emitter.on('slow', function() { assert.fail('does not emit "slow" event'); });
+    util.putTileRetry(source, 0, 0, 0, new Buffer(0), 0, emitter, function(err) {
+        assert.equal(source.fails['0/0/0'], undefined, 'failed x0');
+        assert.ifError(err, 'no error');
+        assert.end();
+    });
+});
 
 test('getTileRetry fail=2, retry=2', function(assert) {
     var source = new Timedsource({fail:2});
@@ -155,6 +166,20 @@ test('getTileRetry (slow)', function(assert) {
         assert.ifError(err, 'no error');
         assert.equal(data instanceof Buffer, true, 'passes buffer');
         assert.deepEqual(headers, {}, 'passes headers');
+    });
+});
+
+test('getTileRetry (slow=0)', function(assert) {
+    util.slowTime = 0;
+    var source = new Timedsource({fail:0, time:50});
+    var emitter = new EventEmitter();
+    emitter.on('slow', function() { assert.fail('does not emit "slow" event'); });
+    util.getTileRetry(source, 0, 0, 0, 0, emitter, function(err, data, headers) {
+        assert.equal(source.fails['0/0/0'], undefined, 'failed x0');
+        assert.ifError(err, 'no error');
+        assert.equal(data instanceof Buffer, true, 'passes buffer');
+        assert.deepEqual(headers, {}, 'passes headers');
+        assert.end();
     });
 });
 


### PR DESCRIPTION
- Always: changes getTileRetry and putTileRetry util functions to take a stream object and emit `slow` events when a tile op exceeds the `slowTime` threshold. `slowTime` threshold defaults to 60s.
- Optional: if `options.slow = <time in ms>` is passed to `tilelive.copy()`, copy sets the threshold and adds handlers for outputting to `stderr` whenever the `slow` event is emitted.
- Exposes this option to tilelive-copy bin.

This would start 5.10.x 

@rclark :eyes: ?