### PR TITLE
We don't know if it will be the get or put that reports as slow

### DIFF
--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -106,7 +106,7 @@ test('copy slow', function(t) {
     var filepath = path.join(tmp, crypto.randomBytes(12).toString('hex') + '.copy_slow.mbtiles');
     exec(__dirname + '/../bin/tilelive-copy --slow=20 ' + __dirname + '/fixtures/plain_1.mbtiles ' + filepath, function(err, stdout, stderr) {
         t.ifError(err, 'no errors');
-        t.ok((/\[slow tile\] get \d+\/\d+\/\d+ \d+ms/).test(stderr), 'logs slow tiles to stderr');
+        t.ok((/\[slow tile\] (get|put) \d+\/\d+\/\d+ \d+ms/).test(stderr), 'logs slow tiles to stderr');
         t.end();
     });
 });


### PR DESCRIPTION
The `--slow` test added in 93e95a43dddcec171d9dbe364bb579688fb32d90 is failing for me because it is reporting the `put` as slow, not the `get`.

Judging by the equivalent API level test in f3538d47eee18ac5bd4dbd774784541324601099, which allows either method, this is probably expected, so this updates the expected result to allow either method.