### PR TITLE
Use source.createZXYStream() with copy `--list` option if no list provided

### DIFF
--- a/bin/tilelive-copy
+++ b/bin/tilelive-copy
@@ -58,11 +58,6 @@ if (argv.scheme !== 'pyramid' && argv.scheme !== 'scanline' && argv.scheme !== '
     process.exit(1);
 }
 
-if (argv.scheme === 'list' && !argv.list) {
-    console.warn('--list=file required for list scheme');
-    process.exit(1);
-}
-
 var srcuri = argv._[0];
 var dsturi = argv._[1] ? argv._[1] : false;
 // register modules
@@ -90,7 +85,7 @@ function copy() {
         num:argv.part
     };
     // Create readstream for lists
-    if (options.type === 'list') {
+    if (options.type === 'list' && argv.list) {
         options.listStream = fs.createReadStream(argv.list);
     }
     if (!dsturi) options.outStream = process.stdout;

--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -307,10 +307,6 @@ tilelive.verify = function(ts, required) {
 tilelive.copy = function(src, dst, options, callback) {
     callback = callback || function() {};
 
-    if (options.type === 'list' && !options.listStream) {
-        return callback(new Error('You must provide a listStream'));
-    }
-
     if (!dst && !options.outStream) {
         return callback(new Error('You must provide either a dsturi or an output stream'));
     }
@@ -364,6 +360,13 @@ tilelive.copy = function(src, dst, options, callback) {
     });
 
     function copy(src, dst, opts, callback) {
+        if (opts.type === 'list') {
+            opts.listStream = opts.listStream || (src.createZXYStream ? src.createZXYStream() : null);
+            if (!opts.listStream) {
+                return callback(new Error('You must provide a listStream'));
+            }
+        }
+
         // sinkStream represents a copy to a non-tilelive stream
         var sinkStream = !dst && opts.outStream;
 

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -172,11 +172,13 @@ test('tilelive copy: list', function(t) {
     var dst = path.join(tmp, crypto.randomBytes(12).toString('hex') + '.tilelivecopy_list.mbtiles');
     var list = __dirname + '/fixtures/plain_1.tilelist';
     var options = {};
+    var stats = {};
     options.type = 'list';
-    options.progress = report;
+    options.progress = function(s) { stats = s; };
     options.listStream = fs.createReadStream(list);
     tilelive.copy(src, dst, options, function(err){
         if (err) throw err;
+        t.equal(stats.ops, 285, '285 ops');
         t.ifError(err);
         t.end();
     });
@@ -186,10 +188,12 @@ test('tilelive copy: list auto', function(t) {
     var src = __dirname + '/fixtures/plain_1.mbtiles';
     var dst = path.join(tmp, crypto.randomBytes(12).toString('hex') + '.tilelivecopy_listauto.mbtiles');
     var options = {};
+    var stats = {};
     options.type = 'list';
-    options.progress = report;
+    options.progress = function(s) { stats = s; };
     tilelive.copy(src, dst, options, function(err){
         if (err) throw err;
+        t.equal(stats.ops, 285, '285 ops');
         t.ifError(err);
         t.end();
     });

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -182,10 +182,22 @@ test('tilelive copy: list', function(t) {
     });
 });
 
-test('tilelive copy: missing liststream', function(t) {
+test('tilelive copy: list auto', function(t) {
     var src = __dirname + '/fixtures/plain_1.mbtiles';
+    var dst = path.join(tmp, crypto.randomBytes(12).toString('hex') + '.tilelivecopy_listauto.mbtiles');
+    var options = {};
+    options.type = 'list';
+    options.progress = report;
+    tilelive.copy(src, dst, options, function(err){
+        if (err) throw err;
+        t.ifError(err);
+        t.end();
+    });
+});
+
+test('tilelive copy: missing liststream', function(t) {
+    var src = 'tilejson+http://api.mapbox.com/v3/mapbox.world-bright.json';
     var dst = path.join(tmp, crypto.randomBytes(12).toString('hex') + '.tilelivecopy_liststream.mbtiles');
-    var list = __dirname + '/fixtures/plain_1.tilelist';
     var options = {};
     options.type = 'list';
     options.progress = report;


### PR DESCRIPTION
If a source provides a `createZXYStream()` method, use it for copying in list mode if no explicit list is provided.

- [x] Add additional test assertions which show the zxy stream was actually used...

cc @rclark 