### PR TITLE
Optionally: exit 0 on tilelive-copy

### DIFF
--- a/bin/tilelive-copy
+++ b/bin/tilelive-copy
@@ -31,6 +31,7 @@ if (!argv._[0]) {
     console.log('  --withoutprogress                 Shows progress by default.');
     console.log('  --timeout=[number]                Timeout after n ms of inactivity.');
     console.log('  --slow=[number]                   Warn on slow tiles.');
+    console.log('  --exit                            Exit explicitly when copy is complete.');
     console.log('  --bounds=[w,s,e,n]');
     console.log('  --minzoom=[number]');
     console.log('  --maxzoom=[number]');
@@ -52,6 +53,7 @@ argv.part = isNumeric(argv.part) ? argv.part : undefined;
 argv.retry = isNumeric(argv.retry) ? parseInt(argv.retry,10) : undefined;
 argv.timeout = isNumeric(argv.timeout) ? parseInt(argv.timeout,10) : undefined;
 argv.slow = isNumeric(argv.slow) ? parseInt(argv.slow,10) : undefined;
+argv.exit = argv.exit || undefined;
 
 if (argv.scheme !== 'pyramid' && argv.scheme !== 'scanline' && argv.scheme !== 'list') {
     console.warn('scheme must be one of pyramid, scanline, list');
@@ -97,6 +99,7 @@ function copy() {
     tilelive.copy(srcuri, dsturi, options, function(err) {
         if (err) throw err;
         console.log('');
+        if (argv.exit) process.exit(0);
     });
 }
 


### PR DESCRIPTION
Adds `--exit` flag for optionally forcing a `process.exit(0)` when tilelive-copy complete successfully rather than waiting for node to exit. Addresses some resources being held onto at the end of a copy leading to hangs.