### PR TITLE
Log progress to a single line using a non-deprecated function

### DIFF
--- a/bin/tilelive-copy
+++ b/bin/tilelive-copy
@@ -104,7 +104,7 @@ function copy() {
 }
 
 function report(stats, p) {
-    console.log(util.format('\r\033[K[%s] %s%% %s/%s @ %s/s | ✓ %s □ %s | %s left',
+    process.stdout.write(util.format('\r\033[K[%s] %s%% %s/%s @ %s/s | ✓ %s □ %s | %s left',
         pad(formatDuration(process.uptime()), 4, true),
         pad((p.percentage).toFixed(4), 8, true),
         pad(formatNumber(p.transferred),6,true),

--- a/bin/tilelive-copy
+++ b/bin/tilelive-copy
@@ -128,7 +128,7 @@ function formatDuration(duration) {
     return (days > 0 ? days + 'd ' : '') +
         (hours > 0 || days > 0 ? hours + 'h ' : '') +
         (minutes > 0 || hours > 0 || days > 0 ? minutes + 'm ' : '') +
-        seconds + 's';
+        seconds.toFixed(1) + 's';
 }
 
 function pad(str, len, r) {


### PR DESCRIPTION
Commit 878d4169dc38995bdfcacab6e223a6441a41d1bb removed the use of a deprecated function to print output progress, but at the expense of making progress scroll endlessly rather than staying on one line. This PR replaces that with process.stdout.write, which seems to be the accepted approach according to the node docs: https://nodejs.org/api/process.html#process_process_stdout