### PR TITLE
Add error handling for the transform stream

### DIFF
--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -415,7 +415,10 @@ tilelive.copy = function(src, dst, options, callback) {
             put.on(doneEvent, done);
 
         var pipeline = opts.type === 'list' ? opts.listStream.pipe(get) : get;
-        if (options.transform) pipeline = pipeline.pipe(options.transform);
+        if (options.transform) {
+            pipeline = pipeline.pipe(options.transform);
+            pipeline.on('error', done);
+        }
         if (sinkStream) pipeline = pipeline.pipe(tilelive.serialize());
         pipeline.pipe(prog).pipe(put);
     }

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -419,6 +419,21 @@ test('tilelive.copy transform', function(t) {
     });
 });
 
+test('tilelive.copy transform errors', function(t) {
+    var src = __dirname + '/fixtures/plain_1.mbtiles';
+    var dst = path.join(tmp, crypto.randomBytes(12).toString('hex') + '.tilelivecopy.mbtiles');
+    var transform = new stream.Transform({ objectMode: true });
+    transform._transform = function(tile, enc, callback) {
+        return callback(new Error('hello error'));
+    };
+
+    tilelive.copy(src, dst, { transform: transform }, function(err){
+        t.ok(err, 'failed');
+        t.equal(err.message, 'hello error', 'error was passed to the callback');
+        t.end();
+    });
+});
+
 test('tilelive.copy not a transform', function(t) {
     var src = __dirname + '/fixtures/plain_1.mbtiles';
     var dst = path.join(tmp, crypto.randomBytes(12).toString('hex') + '.tilelivecopy.mbtiles');


### PR DESCRIPTION
There wasn't error handling on the transform stream, which would previously just throw when the transform stream errored.

cc/ @rclark for a quick review if you could.