### PR TITLE
Allow multiple transform streams

### DIFF
--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -316,8 +316,10 @@ tilelive.copy = function(src, dst, options, callback) {
     if (options.slow) tilelive.stream.slowTime = options.slow;
 
     // if (options.transform && (!options.transform._write || !options.transform._read)) {
-    if (options.transform && !(options.transform instanceof stream.Transform)) {
-        return callback(new Error('You must provide a valid transform stream'));
+    if (options.transform &&
+        (!(options.transform instanceof Array) ||
+        !options.transform.every(function(t){ return (t instanceof stream.Transform); }))) {
+        return callback(new Error('You must provide an array of valid transform streams'));
     }
 
     var prog = progress({
@@ -415,7 +417,11 @@ tilelive.copy = function(src, dst, options, callback) {
             put.on(doneEvent, done);
 
         var pipeline = opts.type === 'list' ? opts.listStream.pipe(get) : get;
-        if (options.transform) pipeline = pipeline.pipe(options.transform);
+        if (options.transform) {
+            options.transform.forEach(function(transform) {
+                pipeline = pipeline.pipe(transform);
+            });
+        }
         if (sinkStream) pipeline = pipeline.pipe(tilelive.serialize());
         pipeline.pipe(prog).pipe(put);
     }


### PR DESCRIPTION
- breaking change to the API that forces the `transform` property to be
  an array
- will require a major version bump and changes downstream

@rclark for the review. Unblocks migration and validation in a tilelive-copy operation.