### PR TITLE
Allow transform-like streams to be used

### DIFF
--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -316,7 +316,7 @@ tilelive.copy = function(src, dst, options, callback) {
     if (options.slow) tilelive.stream.slowTime = options.slow;
 
     // if (options.transform && (!options.transform._write || !options.transform._read)) {
-    if (options.transform && !(options.transform instanceof stream.Transform)) {
+    if (options.transform && (!options.transform.readable || !options.transform.writable)) {
         return callback(new Error('You must provide a valid transform stream'));
     }
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint": "^0.24.0",
     "istanbul": "~0.3.0",
     "mbtiles": "~0.8.2",
+    "stream-combiner": "^0.2.2",
     "tape": "2.13.3",
     "tilejson": "~1.0.0"
   },


### PR DESCRIPTION
- allows stream-combiner to be used as a transform stream

stream-combiner doesn't produce a transform stream, it produces a stream that quacks like a transform stream though. So no more `instanceof`, just ask it to quack :smile_cat: 

cc/ @rclark 