### PR TITLE
Update badge urls for coveralls and travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # tilelive.js
 
-[![Coverage Status](https://coveralls.io/repos/mapbox/tilelive.js/badge.svg)](https://coveralls.io/r/mapbox/tilelive.js)
+[![Coverage Status](https://coveralls.io/repos/mapbox/tilelive/badge.svg)](https://coveralls.io/r/mapbox/tilelive)
 
 - Tilelive is a module to help interactions between tilelive source modules.
 - A tilelive source is an interface implemented by node modules that deal with reading and writing map tiles.
 
-[![Build Status](https://secure.travis-ci.org/mapbox/tilelive.js.svg)](http://travis-ci.org/mapbox/tilelive.js)
+[![Build Status](https://secure.travis-ci.org/mapbox/tilelive.svg)](http://travis-ci.org/mapbox/tilelive)
 
 ## Implementing modules
 


### PR DESCRIPTION
Badge URLs were still pointing to mapbox/tilelive.js not mapbox/tilelive