### PR TITLE
Replace deprecated module

### DIFF
--- a/lib/stream-list.js
+++ b/lib/stream-list.js
@@ -5,7 +5,7 @@ var setConcurrency = require('./stream-util').setConcurrency;
 var getTileRetry = require('./stream-util').getTileRetry;
 var Transform = require('stream').Transform;
 var util = require('util');
-var queue = require('queue-async');
+var queue = require('d3-queue').queue;
 
 module.exports = List;
 util.inherits(List, Transform);

--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -4,7 +4,7 @@ var url = require('url');
 var qs = require('querystring');
 var stream = require('stream');
 var progress = require('progress-stream');
-var queue = require('queue-async');
+var queue = require('d3-queue').queue;
 
 global.tileliveProtocols = global.tileliveProtocols || {};
 

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "Blake Thompson <flippmoke>"
   ],
   "dependencies": {
+    "d3-queue": "^3.0.3",
     "minimist": "~0.2.0",
     "progress-stream": "~0.5.x",
-    "sphericalmercator": "~1.0.1",
-    "queue-async": "~1.0.7"
+    "sphericalmercator": "~1.0.1"
   },
   "devDependencies": {
     "concat-stream": "1.4.x",


### PR DESCRIPTION
This PR replaces deprecated and renamed module `queue-async` into `d3-queue`.