### PR TITLE
errors from transforms are important

### DIFF
--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -420,7 +420,7 @@ tilelive.copy = function(src, dst, options, callback) {
         var pipeline = opts.type === 'list' ? opts.listStream.pipe(get) : get;
         if (options.transform) {
             pipeline = pipeline.pipe(options.transform);
-            pipeline.on('error', done);
+            pipeline.on('error', done(err)); // eslint-disable-line no-undef
         }
         if (sinkStream) pipeline = pipeline.pipe(tilelive.serialize());
         pipeline.pipe(prog).pipe(put);


### PR DESCRIPTION
does this seem kosher? i understand that errors from get/put are noise, but i think errors from a transform stream should be a flag that you're transforming tiles in a way that you might not expect

cc @rclark 