### PR TITLE
support @mapbox namespaced tilelive packages for auto loading

### DIFF
--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -109,7 +109,7 @@ tilelive.auto = function(uri) {
     uri.protocol = uri.protocol || keyword + ':';
 
     if (!tilelive.protocols[uri.protocol]) {
-        [keyword, 'tilelive-' + keyword].forEach(function(name) {
+        [keyword, 'tilelive-' + keyword, '@mapbox/' + keyword, '@mapbox/tilelive-' + keyword].forEach(function(name) {
             try {
                 var mod = require(name);
 


### PR DESCRIPTION
Since we are moving more mapbox packages to the `@mapbox/` namespace, we're running into issues where tilelive can't autoload anymore. For example, `tilelive-s3` is not found anymore because it is now `@mapbox/tilelive-s3`