### PR TITLE
Append-friendlier serial tiles serializer

### DIFF
--- a/lib/stream-deserialize.js
+++ b/lib/stream-deserialize.js
@@ -55,6 +55,7 @@ Deserialize.prototype.deserialize = function(serializedObj) {
 
     var obj = deserialize(serializedObj);
 
+    if (obj === null) return;
     if (obj instanceof Info) this.emit('info', obj);
     if (obj instanceof Tile) this.emit('tile', obj);
     this.push(obj);

--- a/lib/stream-serialize.js
+++ b/lib/stream-serialize.js
@@ -1,7 +1,5 @@
 var stream = require('stream');
 var util = require('util');
-var Tile = require('./stream-util').Tile;
-var Info = require('./stream-util').Info;
 var serialize = require('./stream-util').serialize;
 var serialHeader = require('./stream-util').serialHeader;
 
@@ -19,13 +17,19 @@ function Serialize() {
 Serialize.prototype._transform = function(chunk, enc, callback) {
     var data = this._buffer.pop();
     if (data) this.push(data + '\n');
-    if (chunk instanceof Tile || chunk instanceof Info)
-        this._buffer.push(serialize(chunk));
+
+    var serialized;
+    try {
+        serialized = serialize(chunk);
+    } catch(err) {
+        return callback(err);
+    }
+    this._buffer.push(serialized);
     callback();
 };
 
 Serialize.prototype._flush = function(callback) {
     var data = this._buffer.pop();
-    if (data) this.push(data);
+    if (data) this.push(data + '\n');
     callback();
 };

--- a/lib/stream-util.js
+++ b/lib/stream-util.js
@@ -4,6 +4,7 @@ var util = require('util');
 module.exports = {};
 module.exports.Tile = Tile;
 module.exports.Info = Info;
+module.exports.SerializationError = SerializationError;
 module.exports.DeserializationError = DeserializationError;
 module.exports.Stats = Stats;
 module.exports.addChildren = addChildren;
@@ -20,6 +21,12 @@ module.exports.getTileRetry = getTileRetry;
 module.exports.putTileRetry = putTileRetry;
 module.exports.retryBackoff = 1000;
 module.exports.slowTime = 10e3;
+
+function SerializationError(msg) {
+    this.message = msg;
+    this.name = 'SerializationError';
+}
+util.inherits(SerializationError, Error);
 
 function DeserializationError(msg) {
     this.message = msg;
@@ -43,13 +50,15 @@ function Info(info) {
 function serialize(obj) {
     if (obj instanceof Tile) return serializeTile(obj);
     if (obj instanceof Info) return serializeInfo(obj);
-    return '';
+
+    throw new SerializationError('Invalid data');
 }
 
 function deserialize(data, property) {
     if (property) return getSerializedProperty(data, property);
     if (data.indexOf('{"z":') === 0) return deserializeTile(data);
     if (data.indexOf('{') === 0) return deserializeInfo(data);
+    if (data === '') return null;
 
     throw new DeserializationError('Invalid data');
 }

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -81,7 +81,7 @@ test('copy streams', function(t) {
         t.ifError(err, 'no errors');
         t.equal(stderr, '', 'no stderr');
         t.ok(stdout.indexOf('JSONBREAKFASTTIME\n') === 0);
-        t.equal(stdout.length, 647001);
+        t.equal(stdout.length, 647002);
         t.end();
     });
 });

--- a/test/stream-util.test.js
+++ b/test/stream-util.test.js
@@ -319,6 +319,17 @@ test('Info: deserialize', function(t) {
     }
 });
 
+test('serialize/deserialize corner cases', function(t) {
+    t.deepEqual(util.deserialize(''), null, 'deserialize interprets empty strings as null');
+    t.throws(function() {
+        util.serialize('boogie woogie');
+    }, /SerializationError: Invalid data/, 'serialize throws on invalid data');
+    t.throws(function() {
+        util.serialize('');
+    }, /SerializationError: Invalid data/, 'serialize throws on invalid data');
+    t.end();
+});
+
 test('Limit bounds', function(t) {
 
     // these inputs should simply be equal to themselves, since they don't contain


### PR DESCRIPTION
### Context

The serialtiles serializer is written like a pretty reasonable newline delimited stream writer with the one exception that in the final `_flush` case it decides to not write a trailing newline. This causes all kinds of headaches for anyone attempting to resume or append to a previously written serialtiles files.

What happens now (newlines visualized for ease). Note that the last line does not have a trailing `\n`.

```
JSONBREAKFASTTIME\n
{ ... }\n
{ ... }\n
{ ... }
```

Now let's append to this stream assuming we can write in a way consistent with the previous writes...

```
# appended version
JSONBREAKFASTTIME\n
{ ... }\n
{ ... }\n
{ ... }{ ... }
{ ... }\n
{ ... }\n
...
```

Not great.

### So then appenders do some trickery...

No big deal, appenders can just write lines with a prefixed newline! `\n{ ... }`

```
# appended version
JSONBREAKFASTTIME\n
{ ... }\n
{ ... }\n
{ ... }
\n{ ... }
\n{ ... }
\n{ ... }
```

Great! But what if our append starts after the initial header is written or while another initial stream is writing rather than after the first stream has concluded?

```
# appended version
JSONBREAKFASTTIME\n
\n{ ... }
\n{ ... }
\n{ ... }
```

Oww, now we end up with an empty line (the empty string sandwiched between `\n\n`). 🍔 

---

### Proposed solution

- **Always write a trailing newline.** No weird exception on flush.
- **Add no-op handling for an empty string in deserialize.** This is for the empty string sandwiched between `\n\n` for anyone who's been trying to append and has hit this corner case.
- This branch also adds error handling for bad data passed for serialization (refs #117).

This is a breaking change though some testing indicates previous versions of tilelive handle a single trailing `\n` on serialtiles files fine.

For safety will bump major.

cc @rclark @mapbox/core-tech 