### PR TITLE
Telemetraf-3602: Update to use aws-sdk >= 2.1562

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.1.2
+Updates to work with aws-sdk 2.1562.0:
+* Use the default value of HighWaterMark for the WriteStream interface. With updated aws-sdk version, the HighWaterMark setting was causing write timeouts.
+* New version of aws-sdk does not reliably call the callback fuction of put_object. tilelive depended on that call back to count the number tiles being written. When the callback was not being called tilelive would hang. The solution is just use the finish event that tilelive to indicate that all of the tiles have been written. If an error occures tilelive will catch the error event.
+
 ## 6.1.1
 * Update to minimist version 1.2.6
 

--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -362,7 +362,6 @@ tilelive.copy = function(src, dst, options, callback) {
     });
 
     function copy(src, dst, opts, callback) {
-
         if (opts.type === 'list') {
             opts.listStream = opts.listStream || (src.createZXYStream ? src.createZXYStream() : null);
             if (!opts.listStream) {
@@ -411,11 +410,7 @@ tilelive.copy = function(src, dst, options, callback) {
             prog.on('progress', function(p) { options.progress(get.stats, p); });
 
         var doneEvent = sinkStream ? 'finish' : 'stop';
-
-        console.log("dst is instance of " + dst.constructor.name)
-
         if (dst.constructor.name === 'S3') {
-            console.log("setting doneEvent to finish")
             doneEvent = 'finish'
         }
 

--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -412,7 +412,7 @@ tilelive.copy = function(src, dst, options, callback) {
 
         var doneEvent = sinkStream ? 'finish' : 'stop';
 
-        console.log("dst typeof: " + typeof dst)
+        console.log("dst is instance of " + dst.constructor.name)
 
         if (options.outStream === process.stdout ||
             options.outStream === process.stderr) prog.on('end', done);

--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -362,6 +362,7 @@ tilelive.copy = function(src, dst, options, callback) {
     });
 
     function copy(src, dst, opts, callback) {
+
         if (opts.type === 'list') {
             opts.listStream = opts.listStream || (src.createZXYStream ? src.createZXYStream() : null);
             if (!opts.listStream) {
@@ -411,13 +412,12 @@ tilelive.copy = function(src, dst, options, callback) {
 
         var doneEvent = sinkStream ? 'finish' : 'stop';
 
-        if (dst && dst.source.startsWith('s3:')) {
-            doneEvent = 'finish';
-        }
+        console.log("dst typeof: " + typeof dst)
 
         if (options.outStream === process.stdout ||
             options.outStream === process.stderr) prog.on('end', done);
         else
+            put.on('finish', done)
             put.on(doneEvent, done);
 
         var pipeline = opts.type === 'list' ? opts.listStream.pipe(get) : get;

--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -414,10 +414,14 @@ tilelive.copy = function(src, dst, options, callback) {
 
         console.log("dst is instance of " + dst.constructor.name)
 
+        if (dst.constructor.name === 'S3') {
+            console.log("setting doneEvent to finish")
+            doneEvent = 'finish'
+        }
+
         if (options.outStream === process.stdout ||
             options.outStream === process.stderr) prog.on('end', done);
         else
-            put.on('finish', done)
             put.on(doneEvent, done);
 
         var pipeline = opts.type === 'list' ? opts.listStream.pipe(get) : get;

--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -411,7 +411,7 @@ tilelive.copy = function(src, dst, options, callback) {
 
         var doneEvent = sinkStream ? 'finish' : 'stop';
 
-        if (dst && dst.startsWith('s3:')) {
+        if (dst && dst.source.startsWith('s3:')) {
             doneEvent = 'finish';
         }
 

--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -411,6 +411,10 @@ tilelive.copy = function(src, dst, options, callback) {
 
         var doneEvent = sinkStream ? 'finish' : 'stop';
 
+        if (dst && dst.startsWith('s3:')) {
+            doneEvent = 'finish';
+        }
+
         if (options.outStream === process.stdout ||
             options.outStream === process.stderr) prog.on('end', done);
         else
@@ -460,7 +464,6 @@ tilelive.createReadStream = function(source, options) {
 
 tilelive.createWriteStream = function(source, options) {
     options = options || {};
-    options.highWaterMark = options.highWaterMark || 2 * tilelive.stream.setConcurrency();
     options.type = options.type || 'put';
     if (options.type === 'list') throw new Error(options.type + ' is not a valid writable stream type');
     var result = new tilelive.streamTypes[options.type](source, options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tilelive",
-  "version": "6.1.2-dev2",
+  "version": "6.1.2-dev3",
   "main": "./lib/tilelive.js",
   "description": "API for various map tile backends",
   "url": "http://github.com/mapbox/tilelive.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tilelive",
-  "version": "6.1.2.dev1",
+  "version": "6.1.2-dev1",
   "main": "./lib/tilelive.js",
   "description": "API for various map tile backends",
   "url": "http://github.com/mapbox/tilelive.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tilelive",
-  "version": "6.1.1",
+  "version": "6.1.2.dev1",
   "main": "./lib/tilelive.js",
   "description": "API for various map tile backends",
   "url": "http://github.com/mapbox/tilelive.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tilelive",
-  "version": "6.1.2-dev3",
+  "version": "6.1.2-dev4",
   "main": "./lib/tilelive.js",
   "description": "API for various map tile backends",
   "url": "http://github.com/mapbox/tilelive.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tilelive",
-  "version": "6.1.2-dev4",
+  "version": "6.1.2-dev5",
   "main": "./lib/tilelive.js",
   "description": "API for various map tile backends",
   "url": "http://github.com/mapbox/tilelive.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tilelive",
-  "version": "6.1.2-dev5",
+  "version": "6.1.2",
   "main": "./lib/tilelive.js",
   "description": "API for various map tile backends",
   "url": "http://github.com/mapbox/tilelive.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tilelive",
-  "version": "6.1.2-dev1",
+  "version": "6.1.2-dev2",
   "main": "./lib/tilelive.js",
   "description": "API for various map tile backends",
   "url": "http://github.com/mapbox/tilelive.js",


### PR DESCRIPTION
## 6.1.2
Updates to work with S3 client of aws-sdk 2.1562.0:
* Use the default value of HighWaterMark for the WriteStream interface. With the updated aws-sdk version, the HighWaterMark setting was causing write timeouts.
* New version of aws-sdk does not reliably call the callback fuction of put_object. tilelive depended on that call back to count the number tiles being written. When the callback was not being called tilelive would hang. The solution is just use the finish event that tilelive to indicate that all of the tiles have been written. If an error occures tilelive will catch the error event.
